### PR TITLE
Fix the comments for rising/falling inflection

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -398,7 +398,7 @@ do
     // period phoneme *.
     if (A == 1)
     {
-       // add rising inflection
+       // add falling inflection
         A = 1;
         mem48 = 1;
         //goto pos48376;
@@ -411,7 +411,7 @@ do
     // question mark phoneme?
     if (A == 2)
     {
-        // create falling inflection
+        // create rising inflection
         mem48 = 255;
         AddInflection(mem48, phase1);
     }


### PR DESCRIPTION
The original SAM docs at http://www.retrobits.net/atari/sam.shtml#ch3.0
say: "The period inserts a pause and also causes the pitch to fall. The
question-mark also inserts a pause, but it causes the pitch to rise."