### PR TITLE
Change variable names to fix linker error

### DIFF
--- a/src/sam.c
+++ b/src/sam.c
@@ -27,7 +27,7 @@ unsigned char mem56;
 
 unsigned char mem59=0;
 
-unsigned char A, X, Y;
+unsigned char A1, X1, Y1;
 
 unsigned char stress[256]; //numbers from 0 to 8
 unsigned char phonemeLength[256]; //tab40160
@@ -150,14 +150,14 @@ int SAMMain()
     Code41240();
     do
     {
-        A = phonemeindex[X];
-        if (A > 80)
+        A1 = phonemeindex[X1];
+        if (A1 > 80)
         {
-            phonemeindex[X] = 255;
+            phonemeindex[X1] = 255;
             break; // error: delete all behind it
         }
-        X++;
-    } while (X != 0);
+        X1++;
+    } while (X1 != 0);
 
     //pos39848:
     InsertBreath();
@@ -177,45 +177,45 @@ int SAMMain()
 //void Code48547()
 void PrepareOutput()
 {
-    A = 0;
-    X = 0;
-    Y = 0;
+    A1 = 0;
+    X1 = 0;
+    Y1 = 0;
 
     //pos48551:
     while(1)
     {
-        A = phonemeindex[X];
-        if (A == 255)
+        A1 = phonemeindex[X1];
+        if (A1 == 255)
         {
-            A = 255;
-            phonemeIndexOutput[Y] = 255;
+            A1 = 255;
+            phonemeIndexOutput[Y1] = 255;
             Render();
             return;
         }
-        if (A == 254)
+        if (A1 == 254)
         {
-            X++;
-            int temp = X;
+            X1++;
+            int temp = X1;
             //mem[48546] = X;
-            phonemeIndexOutput[Y] = 255;
+            phonemeIndexOutput[Y1] = 255;
             Render();
             //X = mem[48546];
-            X=temp;
-            Y = 0;
+            X1=temp;
+            Y1 = 0;
             continue;
         }
 
-        if (A == 0)
+        if (A1 == 0)
         {
-            X++;
+            X1++;
             continue;
         }
 
-        phonemeIndexOutput[Y] = A;
-        phonemeLengthOutput[Y] = phonemeLength[X];
-        stressOutput[Y] = stress[X];
-        X++;
-        Y++;
+        phonemeIndexOutput[Y1] = A1;
+        phonemeLengthOutput[Y1] = phonemeLength[X1];
+        stressOutput[Y1] = stress[X1];
+        X1++;
+        Y1++;
     }
 }
 
@@ -226,45 +226,45 @@ void InsertBreath()
     unsigned char mem55;
     unsigned char index; //variable Y
     mem54 = 255;
-    X++;
+    X1++;
     mem55 = 0;
     unsigned char mem66 = 0;
     while(1)
     {
         //pos48440:
-        X = mem66;
-        index = phonemeindex[X];
+        X1 = mem66;
+        index = phonemeindex[X1];
         if (index == 255) return;
-        mem55 += phonemeLength[X];
+        mem55 += phonemeLength[X1];
 
         if (mem55 < 232)
         {
             if (index != 254) // ML : Prevents an index out of bounds problem
             {
-                A = flags2[index]&1;
-                if(A != 0)
+                A1 = flags2[index]&1;
+                if(A1 != 0)
                 {
-                    X++;
+                    X1++;
                     mem55 = 0;
-                    Insert(X, 254, mem59, 0);
+                    Insert(X1, 254, mem59, 0);
                     mem66++;
                     mem66++;
                     continue;
                 }
             }
-            if (index == 0) mem54 = X;
+            if (index == 0) mem54 = X1;
             mem66++;
             continue;
         }
-        X = mem54;
-        phonemeindex[X] = 31;   // 'Q*' glottal stop
-        phonemeLength[X] = 4;
-        stress[X] = 0;
-        X++;
+        X1 = mem54;
+        phonemeindex[X1] = 31;   // 'Q*' glottal stop
+        phonemeLength[X1] = 4;
+        stress[X1] = 0;
+        X1++;
         mem55 = 0;
-        Insert(X, 254, mem59, 0);
-        X++;
-        mem66 = X;
+        Insert(X1, 254, mem59, 0);
+        X1++;
+        mem66 = X1;
     }
 
 }
@@ -291,33 +291,33 @@ void CopyStress()
     while(1)
     {
         // get the phomene
-        Y = phonemeindex[pos];
+        Y1 = phonemeindex[pos];
 
         // exit at end of buffer
-        if (Y == 255) return;
+        if (Y1 == 255) return;
 
         // if CONSONANT_FLAG set, skip - only vowels get stress
-        if ((flags[Y] & 64) == 0) {pos++; continue;}
+        if ((flags[Y1] & 64) == 0) {pos++; continue;}
         // get the next phoneme
-        Y = phonemeindex[pos+1];
-        if (Y == 255) //prevent buffer overflow
+        Y1 = phonemeindex[pos+1];
+        if (Y1 == 255) //prevent buffer overflow
         {
             pos++; continue;
         } else
         // if the following phoneme is a vowel, skip
-        if ((flags[Y] & 128) == 0)  {pos++; continue;}
+        if ((flags[Y1] & 128) == 0)  {pos++; continue;}
 
         // get the stress value at the next position
-        Y = stress[pos+1];
+        Y1 = stress[pos+1];
 
         // if next phoneme is not stressed, skip
-        if (Y == 0)  {pos++; continue;}
+        if (Y1 == 0)  {pos++; continue;}
 
         // if next phoneme is not a VOWEL OR ER, skip
-        if ((Y & 128) != 0)  {pos++; continue;}
+        if ((Y1 & 128) != 0)  {pos++; continue;}
 
         // copy stress from prior phoneme to this one
-        stress[pos] = Y+1;
+        stress[pos] = Y1+1;
 
         // advance pointer
         pos++;
@@ -400,9 +400,9 @@ int Parser1()
     unsigned char sign1;
     unsigned char sign2;
     unsigned char position = 0;
-    X = 0;
-    A = 0;
-    Y = 0;
+    X1 = 0;
+    A1 = 0;
+    Y1 = 0;
 
     // CLEAR THE STRESS TABLE
     for(i=0; i<256; i++)
@@ -413,7 +413,7 @@ int Parser1()
     while(1)
     {
         // GET THE FIRST CHARACTER FROM THE PHONEME BUFFER
-        sign1 = input[X];
+        sign1 = input[X1];
         // TEST FOR 155 (�) END OF LINE MARKER
         if (sign1 == 155)
         {
@@ -424,8 +424,8 @@ int Parser1()
         }
 
         // GET THE NEXT CHARACTER FROM THE BUFFER
-        X++;
-        sign2 = input[X];
+        X1++;
+        sign2 = input[X1];
 
         // NOW sign1 = FIRST CHARACTER OF PHONEME, AND sign2 = SECOND CHARACTER OF PHONEME
 
@@ -433,28 +433,28 @@ int Parser1()
        // IGNORE PHONEMES IN TABLE ENDING WITH WILDCARDS
 
        // SET INDEX TO 0
-        Y = 0;
+        Y1 = 0;
 pos41095:
 
          // GET FIRST CHARACTER AT POSITION Y IN signInputTable
          // --> should change name to PhonemeNameTable1
-        A = signInputTable1[Y];
+        A1 = signInputTable1[Y1];
 
         // FIRST CHARACTER MATCHES?
-        if (A == sign1)
+        if (A1 == sign1)
         {
            // GET THE CHARACTER FROM THE PhonemeSecondLetterTable
-            A = signInputTable2[Y];
+            A1 = signInputTable2[Y1];
             // NOT A SPECIAL AND MATCHES SECOND CHARACTER?
-            if ((A != '*') && (A == sign2))
+            if ((A1 != '*') && (A1 == sign2))
             {
                // STORE THE INDEX OF THE PHONEME INTO THE phomeneIndexTable
-                phonemeindex[position] = Y;
+                phonemeindex[position] = Y1;
 
                 // ADVANCE THE POINTER TO THE phonemeIndexTable
                 position++;
                 // ADVANCE THE POINTER TO THE phonemeInputBuffer
-                X++;
+                X1++;
 
                 // CONTINUE PARSING
                 continue;
@@ -464,24 +464,24 @@ pos41095:
         // NO MATCH, TRY TO MATCH ON FIRST CHARACTER TO WILDCARD NAMES (ENDING WITH '*')
 
         // ADVANCE TO THE NEXT POSITION
-        Y++;
+        Y1++;
         // IF NOT END OF TABLE, CONTINUE
-        if (Y != 81) goto pos41095;
+        if (Y1 != 81) goto pos41095;
 
 // REACHED END OF TABLE WITHOUT AN EXACT (2 CHARACTER) MATCH.
 // THIS TIME, SEARCH FOR A 1 CHARACTER MATCH AGAINST THE WILDCARDS
 
 // RESET THE INDEX TO POINT TO THE START OF THE PHONEME NAME TABLE
-        Y = 0;
+        Y1 = 0;
 pos41134:
 // DOES THE PHONEME IN THE TABLE END WITH '*'?
-        if (signInputTable2[Y] == '*')
+        if (signInputTable2[Y1] == '*')
         {
 // DOES THE FIRST CHARACTER MATCH THE FIRST LETTER OF THE PHONEME
-            if (signInputTable1[Y] == sign1)
+            if (signInputTable1[Y1] == sign1)
             {
                 // SAVE THE POSITION AND MOVE AHEAD
-                phonemeindex[position] = Y;
+                phonemeindex[position] = Y1;
 
                 // ADVANCE THE POINTER
                 position++;
@@ -490,24 +490,24 @@ pos41134:
                 continue;
             }
         }
-        Y++;
-        if (Y != 81) goto pos41134; //81 is size of PHONEME NAME table
+        Y1++;
+        if (Y1 != 81) goto pos41134; //81 is size of PHONEME NAME table
 
 // FAILED TO MATCH WITH A WILDCARD. ASSUME THIS IS A STRESS
 // CHARACTER. SEARCH THROUGH THE STRESS TABLE
 
         // SET INDEX TO POSITION 8 (END OF STRESS TABLE)
-        Y = 8;
+        Y1 = 8;
 
        // WALK BACK THROUGH TABLE LOOKING FOR A MATCH
-        while( (sign1 != stressInputTable[Y]) && (Y>0))
+        while( (sign1 != stressInputTable[Y1]) && (Y1>0))
         {
   // DECREMENT INDEX
-            Y--;
+            Y1--;
         }
 
         // REACHED THE END OF THE SEARCH WITHOUT BREAKING OUT OF LOOP?
-        if (Y == 0)
+        if (Y1 == 0)
         {
             //mem[39444] = X;
             //41181: JSR 42043 //Error
@@ -515,7 +515,7 @@ pos41134:
             return 0;
         }
 // SET THE STRESS FOR THE PRIOR PHONEME
-        stress[position-1] = Y;
+        stress[position-1] = Y1;
     } //while
 }
 
@@ -526,13 +526,13 @@ pos41134:
 //void Code41203()
 void SetPhonemeLength()
 {
-    unsigned char A;
+    unsigned char A1;
     int position = 0;
     while(phonemeindex[position] != 255 )
     {
-        A = stress[position];
+        A1 = stress[position];
         //41218: BMI 41229
-        if ((A == 0) || ((A&128) != 0))
+        if ((A1 == 0) || ((A1&128) != 0))
         {
             phonemeLength[position] = phonemeLengthTable[phonemeindex[position]];
         } else
@@ -551,7 +551,7 @@ void Code41240()
     while(phonemeindex[pos] != 255)
     {
         unsigned char index; //register AC
-        X = pos;
+        X1 = pos;
         index = phonemeindex[pos];
         if ((flags[index]&2) == 0)
         {
@@ -568,14 +568,14 @@ void Code41240()
 
         do
         {
-            X++;
-            A = phonemeindex[X];
-        } while(A==0);
+            X1++;
+            A1 = phonemeindex[X1];
+        } while(A1==0);
 
-        if (A != 255)
+        if (A1 != 255)
         {
-            if ((flags[A] & 8) != 0)  {pos++; continue;}
-            if ((A == 36) || (A == 37)) {pos++; continue;} // '/H' '/X'
+            if ((flags[A1] & 8) != 0)  {pos++; continue;}
+            if ((A1 == 36) || (A1 == 37)) {pos++; continue;} // '/H' '/X'
         }
 
         Insert(pos+1, index+1, phonemeLengthTable[index+1], stress[pos]);
@@ -622,15 +622,15 @@ void Parser2()
     while(1)
     {
 // SET X TO THE CURRENT POSITION
-        X = pos;
+        X1 = pos;
 // GET THE PHONEME AT THE CURRENT POSITION
-        A = phonemeindex[pos];
+        A1 = phonemeindex[pos];
 
 // DEBUG: Print phoneme and index
-        if (debug && A != 255) printf("%d: %c%c\n", X, signInputTable1[A], signInputTable2[A]);
+        if (debug && A1 != 255) printf("%d: %c%c\n", X1, signInputTable1[A1], signInputTable2[A1]);
 
 // Is phoneme pause?
-        if (A == 0)
+        if (A1 == 0)
         {
 // Move ahead to the
             pos++;
@@ -638,10 +638,10 @@ void Parser2()
         }
 
 // If end of phonemes flag reached, exit routine
-        if (A == 255) return;
+        if (A1 == 255) return;
 
 // Copy the current phoneme index to Y
-        Y = A;
+        Y1 = A1;
 
 // RULE:
 //       <DIPHTONG ENDING WITH WX> -> <DIPHTONG ENDING WITH WX> WX
@@ -650,23 +650,23 @@ void Parser2()
 
 
 // Check for DIPHTONG
-        if ((flags[A] & 16) == 0) goto pos41457;
+        if ((flags[A1] & 16) == 0) goto pos41457;
 
 // Not a diphthong. Get the stress
         mem58 = stress[pos];
 
 // End in IY sound?
-        A = flags[Y] & 32;
+        A1 = flags[Y1] & 32;
 
 // If ends with IY, use YX, else use WX
-        if (A == 0) A = 20; else A = 21;    // 'WX' = 20 'YX' = 21
+        if (A1 == 0) A1 = 20; else A1 = 21;    // 'WX' = 20 'YX' = 21
         //pos41443:
 // Insert at WX or YX following, copying the stress
 
-        if (debug) if (A==20) printf("RULE: insert WX following diphtong NOT ending in IY sound\n");
-        if (debug) if (A==21) printf("RULE: insert YX following diphtong ending in IY sound\n");
-        Insert(pos+1, A, mem59, mem58);
-        X = pos;
+        if (debug) if (A1==20) printf("RULE: insert WX following diphtong NOT ending in IY sound\n");
+        if (debug) if (A1==21) printf("RULE: insert YX following diphtong ending in IY sound\n");
+        Insert(pos+1, A1, mem59, mem58);
+        X1 = pos;
 // Jump to ???
         goto pos41749;
 
@@ -679,21 +679,21 @@ pos41457:
 // Example: MEDDLE
 
 // Get phoneme
-        A = phonemeindex[X];
+        A1 = phonemeindex[X1];
 // Skip this rule if phoneme is not UL
-        if (A != 78) goto pos41487;  // 'UL'
-        A = 24;         // 'L'                 //change 'UL' to 'AX L'
+        if (A1 != 78) goto pos41487;  // 'UL'
+        A1 = 24;         // 'L'                 //change 'UL' to 'AX L'
 
         if (debug) printf("RULE: UL -> AX L\n");
 
 pos41466:
 // Get current phoneme stress
-        mem58 = stress[X];
+        mem58 = stress[X1];
 
 // Change UL to AX
-        phonemeindex[X] = 13;  // 'AX'
+        phonemeindex[X1] = 13;  // 'AX'
 // Perform insert. Note code below may jump up here with different values
-        Insert(X+1, A, mem59, mem58);
+        Insert(X1+1, A1, mem59, mem58);
         pos++;
 // Move to next phoneme
         continue;
@@ -705,9 +705,9 @@ pos41487:
 // Example: ASTRONOMY
 
 // Skip rule if phoneme != UM
-        if (A != 79) goto pos41495;   // 'UM'
+        if (A1 != 79) goto pos41495;   // 'UM'
         // Jump up to branch - replaces current phoneme with AX and continues
-        A = 27; // 'M'  //change 'UM' to  'AX M'
+        A1 = 27; // 'M'  //change 'UM' to  'AX M'
         if (debug) printf("RULE: UM -> AX M\n");
         goto pos41466;
 pos41495:
@@ -718,10 +718,10 @@ pos41495:
 
 
 // Skip rule if phoneme != UN
-        if (A != 80) goto pos41503; // 'UN'
+        if (A1 != 80) goto pos41503; // 'UN'
 
         // Jump up to branch - replaces current phoneme with AX and continues
-        A = 28;         // 'N' //change UN to 'AX N'
+        A1 = 28;         // 'N' //change UN to 'AX N'
         if (debug) printf("RULE: UN -> AX N\n");
         goto pos41466;
 pos41503:
@@ -730,49 +730,49 @@ pos41503:
 //       <STRESSED VOWEL> <SILENCE> <STRESSED VOWEL> -> <STRESSED VOWEL> <SILENCE> Q <VOWEL>
 // EXAMPLE: AWAY EIGHT
 
-        Y = A;
+        Y1 = A1;
 // VOWEL set?
-        A = flags[A] & 128;
+        A1 = flags[A1] & 128;
 
 // Skip if not a vowel
-        if (A != 0)
+        if (A1 != 0)
         {
 // Get the stress
-            A = stress[X];
+            A1 = stress[X1];
 
 // If stressed...
-            if (A != 0)
+            if (A1 != 0)
             {
 // Get the following phoneme
-                X++;
-                A = phonemeindex[X];
+                X1++;
+                A1 = phonemeindex[X1];
 // If following phoneme is a pause
 
-                if (A == 0)
+                if (A1 == 0)
                 {
 // Get the phoneme following pause
-                    X++;
-                    Y = phonemeindex[X];
+                    X1++;
+                    Y1 = phonemeindex[X1];
 
 // Check for end of buffer flag
-                    if (Y == 255) //buffer overflow
+                    if (Y1 == 255) //buffer overflow
 // ??? Not sure about these flags
-                        A = 65&128;
+                        A1 = 65&128;
                     else
 // And VOWEL flag to current phoneme's flags
-                        A = flags[Y] & 128;
+                        A1 = flags[Y1] & 128;
 
 // If following phonemes is not a pause
-                    if (A != 0)
+                    if (A1 != 0)
                     {
 // If the following phoneme is not stressed
-                        A = stress[X];
-                        if (A != 0)
+                        A1 = stress[X1];
+                        if (A1 != 0)
                         {
 // Insert a glottal stop and move forward
                             if (debug) printf("RULE: Insert glottal stop between two stressed vowels with space between them\n");
                             // 31 = 'Q'
-                            Insert(X, 31, mem59, 0);
+                            Insert(X1, 31, mem59, 0);
                             pos++;
                             continue;
                         }
@@ -788,15 +788,15 @@ pos41503:
 
 
 // Get current position and phoneme
-        X = pos;
-        A = phonemeindex[pos];
-        if (A != 23) goto pos41611;     // 'R'
+        X1 = pos;
+        A1 = phonemeindex[pos];
+        if (A1 != 23) goto pos41611;     // 'R'
 
 // Look at prior phoneme
-        X--;
-        A = phonemeindex[pos-1];
+        X1--;
+        A1 = phonemeindex[pos-1];
         //pos41567:
-        if (A == 69)                    // 'T'
+        if (A1 == 69)                    // 'T'
         {
 // Change T to CH
             if (debug) printf("RULE: T R -> CH R\n");
@@ -810,7 +810,7 @@ pos41503:
 // Example: DRY
 
 // Prior phonemes D?
-        if (A == 57)                    // 'D'
+        if (A1 == 57)                    // 'D'
         {
 // Change D to J
             phonemeindex[pos-1] = 44;
@@ -824,9 +824,9 @@ pos41503:
 
 
 // If vowel flag is set change R to RX
-        A = flags[A] & 128;
+        A1 = flags[A1] & 128;
         if (debug) printf("RULE: R -> RX\n");
-        if (A != 0) phonemeindex[pos] = 18;  // 'RX'
+        if (A1 != 0) phonemeindex[pos] = 18;  // 'RX'
 
 // continue to next phoneme
         pos++;
@@ -839,13 +839,13 @@ pos41611:
 // Example: ALL
 
 // Is phoneme L?
-        if (A == 24)    // 'L'
+        if (A1 == 24)    // 'L'
         {
 // If prior phoneme does not have VOWEL flag set, move to next phoneme
             if ((flags[phonemeindex[pos-1]] & 128) == 0) {pos++; continue;}
 // Prior phoneme has VOWEL flag set, so change L to LX and move to next phoneme
             if (debug) printf("RULE: <VOWEL> L -> <VOWEL> LX\n");
-            phonemeindex[X] = 19;     // 'LX'
+            phonemeindex[X1] = 19;     // 'LX'
             pos++;
             continue;
         }
@@ -858,7 +858,7 @@ pos41611:
 //       2. Reciter already replaces GS -> GZ
 
 // Is current phoneme S?
-        if (A == 32)    // 'S'
+        if (A1 == 32)    // 'S'
         {
 // If prior phoneme is not G, move to next phoneme
             if (phonemeindex[pos-1] != 60) {pos++; continue;}
@@ -874,19 +874,19 @@ pos41611:
 // Example: COW
 
 // Is current phoneme K?
-        if (A == 72)    // 'K'
+        if (A1 == 72)    // 'K'
         {
 // Get next phoneme
-            Y = phonemeindex[pos+1];
+            Y1 = phonemeindex[pos+1];
 // If at end, replace current phoneme with KX
-            if (Y == 255) phonemeindex[pos] = 75; // ML : prevents an index out of bounds problem
+            if (Y1 == 255) phonemeindex[pos] = 75; // ML : prevents an index out of bounds problem
             else
             {
 // VOWELS AND DIPHTONGS ENDING WITH IY SOUND flag set?
-                A = flags[Y] & 32;
-                if (debug) if (A==0) printf("RULE: K <VOWEL OR DIPHTONG NOT ENDING WITH IY> -> KX <VOWEL OR DIPHTONG NOT ENDING WITH IY>\n");
+                A1 = flags[Y1] & 32;
+                if (debug) if (A1==0) printf("RULE: K <VOWEL OR DIPHTONG NOT ENDING WITH IY> -> KX <VOWEL OR DIPHTONG NOT ENDING WITH IY>\n");
 // Replace with KX
-                if (A == 0) phonemeindex[pos] = 75;  // 'KX'
+                if (A1 == 0) phonemeindex[pos] = 75;  // 'KX'
             }
         }
         else
@@ -897,7 +897,7 @@ pos41611:
 
 
 // Is character a G?
-        if (A == 60)   // 'G'
+        if (A1 == 60)   // 'G'
         {
 // Get the following character
             unsigned char index = phonemeindex[pos+1];
@@ -924,20 +924,20 @@ pos41611:
 //      S KX -> S GX
 // Examples: SPY, STY, SKY, SCOWL
 
-        Y = phonemeindex[pos];
+        Y1 = phonemeindex[pos];
         //pos41719:
 // Replace with softer version?
-        A = flags[Y] & 1;
-        if (A == 0) goto pos41749;
-        A = phonemeindex[pos-1];
-        if (A != 32)    // 'S'
+        A1 = flags[Y1] & 1;
+        if (A1 == 0) goto pos41749;
+        A1 = phonemeindex[pos-1];
+        if (A1 != 32)    // 'S'
         {
-            A = Y;
+            A1 = Y1;
             goto pos41812;
         }
         // Replace with softer version
-        if (debug) printf("RULE: S* %c%c -> S* %c%c\n", signInputTable1[Y], signInputTable2[Y],signInputTable1[Y-12], signInputTable2[Y-12]);
-        phonemeindex[pos] = Y-12;
+        if (debug) printf("RULE: S* %c%c -> S* %c%c\n", signInputTable1[Y1], signInputTable2[Y1],signInputTable1[Y1-12], signInputTable2[Y1-12]);
+        phonemeindex[pos] = Y1-12;
         pos++;
         continue;
 
@@ -951,16 +951,16 @@ pos41749:
 
 //       UW -> UX
 
-        A = phonemeindex[X];
-        if (A == 53)    // 'UW'
+        A1 = phonemeindex[X1];
+        if (A1 == 53)    // 'UW'
         {
 // ALVEOLAR flag set?
-            Y = phonemeindex[X-1];
-            A = flags2[Y] & 4;
+            Y1 = phonemeindex[X1-1];
+            A1 = flags2[Y1] & 4;
 // If not set, continue processing next phoneme
-            if (A == 0) {pos++; continue;}
+            if (A1 == 0) {pos++; continue;}
             if (debug) printf("RULE: <ALVEOLAR> UW -> <ALVEOLAR> UX\n");
-            phonemeindex[X] = 16;
+            phonemeindex[X1] = 16;
             pos++;
             continue;
         }
@@ -970,11 +970,11 @@ pos41779:
 //       CH -> CH CH' (CH requires two phonemes to represent it)
 // Example: CHEW
 
-        if (A == 42)    // 'CH'
+        if (A1 == 42)    // 'CH'
         {
             //        pos41783:
             if (debug) printf("CH -> CH CH+1\n");
-            Insert(X+1, A+1, mem59, stress[X]);
+            Insert(X1+1, A1+1, mem59, stress[X1]);
             pos++;
             continue;
         }
@@ -986,10 +986,10 @@ pos41788:
 // Example: JAY
 
 
-        if (A == 44) // 'J'
+        if (A1 == 44) // 'J'
         {
             if (debug) printf("J -> J J+1\n");
-            Insert(X+1, A+1, mem59, stress[X]);
+            Insert(X1+1, A1+1, mem59, stress[X1]);
             pos++;
             continue;
         }
@@ -1006,40 +1006,40 @@ pos41812:
 
 // Past this point, only process if phoneme is T or D
 
-        if (A != 69)    // 'T'
-        if (A != 57) {pos++; continue;}       // 'D'
+        if (A1 != 69)    // 'T'
+        if (A1 != 57) {pos++; continue;}       // 'D'
         //pos41825:
 
 
 // If prior phoneme is not a vowel, continue processing phonemes
-        if ((flags[phonemeindex[X-1]] & 128) == 0) {pos++; continue;}
+        if ((flags[phonemeindex[X1-1]] & 128) == 0) {pos++; continue;}
 
 // Get next phoneme
-        X++;
-        A = phonemeindex[X];
+        X1++;
+        A1 = phonemeindex[X1];
         //pos41841
 // Is the next phoneme a pause?
-        if (A != 0)
+        if (A1 != 0)
         {
 // If next phoneme is not a pause, continue processing phonemes
-            if ((flags[A] & 128) == 0) {pos++; continue;}
+            if ((flags[A1] & 128) == 0) {pos++; continue;}
 // If next phoneme is stressed, continue processing phonemes
 // FIXME: How does a pause get stressed?
-            if (stress[X] != 0) {pos++; continue;}
+            if (stress[X1] != 0) {pos++; continue;}
 //pos41856:
 // Set phonemes to DX
         if (debug) printf("RULE: Soften T or D following vowel or ER and preceding a pause -> DX\n");
         phonemeindex[pos] = 30;       // 'DX'
         } else
         {
-            A = phonemeindex[X+1];
-            if (A == 255) //prevent buffer overflow
-                A = 65 & 128;
+            A1 = phonemeindex[X1+1];
+            if (A1 == 255) //prevent buffer overflow
+                A1 = 65 & 128;
             else
 // Is next phoneme a vowel or ER?
-                A = flags[A] & 128;
-            if (debug) if (A != 0) printf("RULE: Soften T or D following vowel or ER and preceding a pause -> DX\n");
-            if (A != 0) phonemeindex[pos] = 30;  // 'DX'
+                A1 = flags[A1] & 128;
+            if (debug) if (A1 != 0) printf("RULE: Soften T or D following vowel or ER and preceding a pause -> DX\n");
+            if (A1 != 0) phonemeindex[pos] = 30;  // 'DX'
         }
 
         pos++;
@@ -1071,7 +1071,7 @@ void AdjustLengths()
     // increased by (length * 1.5) + 1
 
     // loop index
-    X = 0;
+    X1 = 0;
     unsigned char index;
 
     // iterate through the phoneme list
@@ -1079,7 +1079,7 @@ void AdjustLengths()
     while(1)
     {
         // get a phoneme
-        index = phonemeindex[X];
+        index = phonemeindex[X1];
 
         // exit loop if end on buffer token
         if (index == 255) break;
@@ -1088,24 +1088,24 @@ void AdjustLengths()
         if((flags2[index] & 1) == 0)
         {
             // skip
-            X++;
+            X1++;
             continue;
         }
 
         // hold index
-        loopIndex = X;
+        loopIndex = X1;
 
         // Loop backwards from this point
 pos48644:
 
         // back up one phoneme
-        X--;
+        X1--;
 
         // stop once the beginning is reached
-        if(X == 0) break;
+        if(X1 == 0) break;
 
         // get the preceding phoneme
-        index = phonemeindex[X];
+        index = phonemeindex[X1];
 
         if (index != 255) //inserted to prevent access overrun
         if((flags[index] & 128) == 0) goto pos48644; // if not a vowel, continue looping
@@ -1114,7 +1114,7 @@ pos48644:
         do
         {
             // test for vowel
-            index = phonemeindex[X];
+            index = phonemeindex[X1];
 
             if (index != 255)//inserted to prevent access overrun
             // test for fricative/unvoiced or not voiced
@@ -1124,25 +1124,25 @@ pos48644:
                 //if(A == 0) goto pos48688;
 
                 // get the phoneme length
-                A = phonemeLength[X];
+                A1 = phonemeLength[X1];
 
                 // change phoneme length to (length * 1.5) + 1
-                A = (A >> 1) + A + 1;
+                A1 = (A1 >> 1) + A1 + 1;
 if (debug) printf("RULE: Lengthen <FRICATIVE> or <VOICED> between <VOWEL> and <PUNCTUATION> by 1.5\n");
 if (debug) printf("PRE\n");
-if (debug) printf("phoneme %d (%c%c) length %d\n", X, signInputTable1[phonemeindex[X]], signInputTable2[phonemeindex[X]], phonemeLength[X]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1, signInputTable1[phonemeindex[X1]], signInputTable2[phonemeindex[X1]], phonemeLength[X1]);
 
-                phonemeLength[X] = A;
+                phonemeLength[X1] = A1;
 
 if (debug) printf("POST\n");
-if (debug) printf("phoneme %d (%c%c) length %d\n", X, signInputTable1[phonemeindex[X]], signInputTable2[phonemeindex[X]], phonemeLength[X]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1, signInputTable1[phonemeindex[X1]], signInputTable2[phonemeindex[X1]], phonemeLength[X1]);
 
             }
             // keep moving forward
-            X++;
-        } while (X != loopIndex);
+            X1++;
+        } while (X1 != loopIndex);
         //  if (X != loopIndex) goto pos48657;
-        X++;
+        X1++;
     }  // while
 
     // Similar to the above routine, but shorten vowels under some circumstances
@@ -1154,19 +1154,19 @@ if (debug) printf("phoneme %d (%c%c) length %d\n", X, signInputTable1[phonemeind
     while(1)
     {
         // get a phoneme
-        X = loopIndex;
-        index = phonemeindex[X];
+        X1 = loopIndex;
+        index = phonemeindex[X1];
 
         // exit routine at end token
         if (index == 255) return;
 
         // vowel?
-        A = flags[index] & 128;
-        if (A != 0)
+        A1 = flags[index] & 128;
+        if (A1 != 0)
         {
             // get next phoneme
-            X++;
-            index = phonemeindex[X];
+            X1++;
+            index = phonemeindex[X1];
 
             // get flags
             if (index == 255)
@@ -1181,8 +1181,8 @@ if (debug) printf("phoneme %d (%c%c) length %d\n", X, signInputTable1[phonemeind
                 if ((index == 18) || (index == 19))  // 'RX' & 'LX'
                 {
                     // get the next phoneme
-                    X++;
-                    index = phonemeindex[X];
+                    X1++;
+                    index = phonemeindex[X1];
 
                     // next phoneme a consonant?
                     if ((flags[index] & 64) != 0) {
@@ -1233,18 +1233,18 @@ if (debug) printf("phoneme %d (%c%c) length %d\n", loopIndex, signInputTable1[ph
                 // <VOWEL> <P*, T*, K*, KX>
 
                 // move back
-                X--;
+                X1--;
 
 if (debug) printf("RULE: <VOWEL> <UNVOICED PLOSIVE> - decrease vowel by 1/8th\n");
 if (debug) printf("PRE\n");
-if (debug) printf("phoneme %d (%c%c) length %d\n", X, signInputTable1[phonemeindex[X]], signInputTable2[phonemeindex[X]],  phonemeLength[X]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1, signInputTable1[phonemeindex[X1]], signInputTable2[phonemeindex[X1]],  phonemeLength[X1]);
 
                 // decrease length by 1/8th
-                mem56 = phonemeLength[X] >> 3;
-                phonemeLength[X] -= mem56;
+                mem56 = phonemeLength[X1] >> 3;
+                phonemeLength[X1] -= mem56;
 
 if (debug) printf("POST\n");
-if (debug) printf("phoneme %d (%c%c) length %d\n", X, signInputTable1[phonemeindex[X]], signInputTable2[phonemeindex[X]], phonemeLength[X]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1, signInputTable1[phonemeindex[X1]], signInputTable2[phonemeindex[X1]], phonemeLength[X1]);
 
                 // move ahead
                 loopIndex++;
@@ -1256,14 +1256,14 @@ if (debug) printf("phoneme %d (%c%c) length %d\n", X, signInputTable1[phonemeind
 
 if (debug) printf("RULE: <VOWEL> <VOICED CONSONANT> - increase vowel by 1/2 + 1\n");
 if (debug) printf("PRE\n");
-if (debug) printf("phoneme %d (%c%c) length %d\n", X-1, signInputTable1[phonemeindex[X-1]], signInputTable2[phonemeindex[X-1]],  phonemeLength[X-1]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1-1, signInputTable1[phonemeindex[X1-1]], signInputTable2[phonemeindex[X1-1]],  phonemeLength[X1-1]);
 
             // decrease length
-            A = phonemeLength[X-1];
-            phonemeLength[X-1] = (A >> 2) + A + 1;     // 5/4*A + 1
+            A1 = phonemeLength[X1-1];
+            phonemeLength[X1-1] = (A1 >> 2) + A1 + 1;     // 5/4*A + 1
 
 if (debug) printf("POST\n");
-if (debug) printf("phoneme %d (%c%c) length %d\n", X-1, signInputTable1[phonemeindex[X-1]], signInputTable2[phonemeindex[X-1]], phonemeLength[X-1]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1-1, signInputTable1[phonemeindex[X1-1]], signInputTable2[phonemeindex[X1-1]], phonemeLength[X1-1]);
 
             // move ahead
             loopIndex++;
@@ -1287,36 +1287,36 @@ if (debug) printf("phoneme %d (%c%c) length %d\n", X-1, signInputTable1[phonemei
             // M*, N*, NX,
 
             // get the next phoneme
-            X++;
-            index = phonemeindex[X];
+            X1++;
+            index = phonemeindex[X1];
 
             // end of buffer?
             if (index == 255)
-               A = 65&2;  //prevent buffer overflow
+               A1 = 65&2;  //prevent buffer overflow
             else
-                A = flags[index] & 2; // check for stop consonant
+                A1 = flags[index] & 2; // check for stop consonant
 
 
             // is next phoneme a stop consonant?
-            if (A != 0)
+            if (A1 != 0)
 
                // B*, D*, G*, GX, P*, T*, K*, KX
 
             {
 if (debug) printf("RULE: <NASAL> <STOP CONSONANT> - set nasal = 5, consonant = 6\n");
 if (debug) printf("POST\n");
-if (debug) printf("phoneme %d (%c%c) length %d\n", X, signInputTable1[phonemeindex[X]], signInputTable2[phonemeindex[X]], phonemeLength[X]);
-if (debug) printf("phoneme %d (%c%c) length %d\n", X-1, signInputTable1[phonemeindex[X-1]], signInputTable2[phonemeindex[X-1]], phonemeLength[X-1]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1, signInputTable1[phonemeindex[X1]], signInputTable2[phonemeindex[X1]], phonemeLength[X1]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1-1, signInputTable1[phonemeindex[X1-1]], signInputTable2[phonemeindex[X1-1]], phonemeLength[X1-1]);
 
                 // set stop consonant length to 6
-                phonemeLength[X] = 6;
+                phonemeLength[X1] = 6;
 
                 // set nasal length to 5
-                phonemeLength[X-1] = 5;
+                phonemeLength[X1-1] = 5;
 
 if (debug) printf("POST\n");
-if (debug) printf("phoneme %d (%c%c) length %d\n", X, signInputTable1[phonemeindex[X]], signInputTable2[phonemeindex[X]], phonemeLength[X]);
-if (debug) printf("phoneme %d (%c%c) length %d\n", X-1, signInputTable1[phonemeindex[X-1]], signInputTable2[phonemeindex[X-1]], phonemeLength[X-1]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1, signInputTable1[phonemeindex[X1]], signInputTable2[phonemeindex[X1]], phonemeLength[X1]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1-1, signInputTable1[phonemeindex[X1-1]], signInputTable2[phonemeindex[X1-1]], phonemeLength[X1-1]);
 
             }
             // move to next phoneme
@@ -1339,8 +1339,8 @@ if (debug) printf("phoneme %d (%c%c) length %d\n", X-1, signInputTable1[phonemei
             do
             {
                 // move ahead
-                X++;
-                index = phonemeindex[X];
+                X1++;
+                index = phonemeindex[X1];
             } while(index == 0);
 
 
@@ -1358,13 +1358,13 @@ if (debug) printf("phoneme %d (%c%c) length %d\n", X-1, signInputTable1[phonemei
             // RULE: <UNVOICED STOP CONSONANT> {optional silence} <STOP CONSONANT>
 if (debug) printf("RULE: <UNVOICED STOP CONSONANT> {optional silence} <STOP CONSONANT> - shorten both to 1/2 + 1\n");
 if (debug) printf("PRE\n");
-if (debug) printf("phoneme %d (%c%c) length %d\n", X, signInputTable1[phonemeindex[X]], signInputTable2[phonemeindex[X]], phonemeLength[X]);
-if (debug) printf("phoneme %d (%c%c) length %d\n", X-1, signInputTable1[phonemeindex[X-1]], signInputTable2[phonemeindex[X-1]], phonemeLength[X-1]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1, signInputTable1[phonemeindex[X1]], signInputTable2[phonemeindex[X1]], phonemeLength[X1]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1-1, signInputTable1[phonemeindex[X1-1]], signInputTable2[phonemeindex[X1-1]], phonemeLength[X1-1]);
 // X gets overwritten, so hold prior X value for debug statement
-int debugX = X;
+int debugX = X1;
             // shorten the prior phoneme length to (length/2 + 1)
-            phonemeLength[X] = (phonemeLength[X] >> 1) + 1;
-            X = loopIndex;
+            phonemeLength[X1] = (phonemeLength[X1] >> 1) + 1;
+            X1 = loopIndex;
 
             // also shorten this phoneme length to (length/2 +1)
             phonemeLength[loopIndex] = (phonemeLength[loopIndex] >> 1) + 1;
@@ -1391,7 +1391,7 @@ if (debug) printf("phoneme %d (%c%c) length %d\n", debugX-1, signInputTable1[pho
             // R*, L*, W*, Y*
 
             // get the prior phoneme
-            index = phonemeindex[X-1];
+            index = phonemeindex[X1-1];
 
             // prior phoneme a stop consonant>
             if((flags[index] & 2) != 0) {
@@ -1399,13 +1399,13 @@ if (debug) printf("phoneme %d (%c%c) length %d\n", debugX-1, signInputTable1[pho
 
 if (debug) printf("RULE: <LIQUID CONSONANT> <DIPHTONG> - decrease by 2\n");
 if (debug) printf("PRE\n");
-if (debug) printf("phoneme %d (%c%c) length %d\n", X, signInputTable1[phonemeindex[X]], signInputTable2[phonemeindex[X]], phonemeLength[X]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1, signInputTable1[phonemeindex[X1]], signInputTable2[phonemeindex[X1]], phonemeLength[X1]);
 
              // decrease the phoneme length by 2 frames (20 ms)
-             phonemeLength[X] -= 2;
+             phonemeLength[X1] -= 2;
 
 if (debug) printf("POST\n");
-if (debug) printf("phoneme %d (%c%c) length %d\n", X, signInputTable1[phonemeindex[X]], signInputTable2[phonemeindex[X]], phonemeLength[X]);
+if (debug) printf("phoneme %d (%c%c) length %d\n", X1, signInputTable1[phonemeindex[X1]], signInputTable2[phonemeindex[X1]], phonemeLength[X1]);
         }
          }
 
@@ -1421,28 +1421,28 @@ if (debug) printf("phoneme %d (%c%c) length %d\n", X, signInputTable1[phonemeind
 void Code47503(unsigned char mem52)
 {
 
-    Y = 0;
+    Y1 = 0;
     if ((mem53 & 128) != 0)
     {
         mem53 = -mem53;
-        Y = 128;
+        Y1 = 128;
     }
-    mem50 = Y;
-    A = 0;
-    for(X=8; X > 0; X--)
+    mem50 = Y1;
+    A1 = 0;
+    for(X1=8; X1 > 0; X1--)
     {
         int temp = mem53;
         mem53 = mem53 << 1;
-        A = A << 1;
-        if (temp >= 128) A++;
-        if (A >= mem52)
+        A1 = A1 << 1;
+        if (temp >= 128) A1++;
+        if (A1 >= mem52)
         {
-            A = A - mem52;
+            A1 = A1 - mem52;
             mem53++;
         }
     }
 
-    mem51 = A;
+    mem51 = A1;
     if ((mem50 & 128) != 0) mem53 = -mem53;
 
 }


### PR DESCRIPTION
Fixed a linker error complaining about variables being defined twice by altering variable names.