### PR TITLE
Fix compilation for macOS, SDL2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ OBJS = reciter.o sam.o render.o main.o debug.o
 CC = gcc
 
 # libsdl present
-CFLAGS =  -Wall -Os -DUSESDL `sdl-config --cflags`
-LFLAGS = `sdl-config --libs`
+CFLAGS =  -Wall -Os -DUSESDL `sdl2-config --cflags`
+LFLAGS = `sdl2-config --libs`
 
 # no libsdl present
 #CFLAGS =  -Wall -Os


### PR DESCRIPTION
Hey,
To compile in macOS, I had to switch to SDL2. In case anyone stumbles upon the same issue, the fix is quite simple: just use `sdl2-config` in place of `sdl-config`. Best,